### PR TITLE
The PHP Constant `DIRECTORY_SEPARATOR` was used to obtain the directory separator.

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -19,7 +19,7 @@ function temporaryFile($template = null, $dir = null)
 {
     $template = $template ?: 'tmp.XXXXXX';
     $dir = $dir !== null ? $dir : sys_get_temp_dir();
-    $dir = $dir ? $dir.'/' : '';
+    $dir = $dir ? $dir. DIRECTORY_SEPARATOR : '';
     $attempts = 5;
 
     do {
@@ -54,7 +54,7 @@ function temporaryDir($template = null, $dir = null)
 {
     $template = $template ?: 'tmp.XXXXXX';
     $dir = $dir !== null ? $dir : sys_get_temp_dir();
-    $dir = $dir ? $dir.'/' : '';
+    $dir = $dir ? $dir. DIRECTORY_SEPARATOR : '';
     $attempts = 5;
 
     do {


### PR DESCRIPTION
Previously the arbitrary value `'/'` was used as directory separator in the code, which may cause some problem in **Windows based machines**.  

https://github.com/cs278/php-mktemp/blob/9053b3f8f8ec66d7ac2b71605357d7dc195ead8a/src/functions.php#L22

https://github.com/cs278/php-mktemp/blob/9053b3f8f8ec66d7ac2b71605357d7dc195ead8a/src/functions.php#L57

Instead `DIRECTORY_SEPARATOR` PHP Constant was used to avoid platform dependence.